### PR TITLE
nit: Ignore gcode from repo language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# .gitattributes
+*.gcode linguist-vendored=true
+


### PR DESCRIPTION
The main language used here is typescript, so ignore all gcode examples in the repos language statistics